### PR TITLE
Hotfix, Timezone fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "emotion-theming": "^10.0.27",
+    "luxon": "^2.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-feather": "^2.0.8",

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,13 +19,11 @@ import {
     Stack,
     AspectRatioBox,
     StatGroup,
+    Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import {
-    formatDateTime,
-    formatDateTimeWithTimeZone,
-} from "../utils/format-date";
+import { formatDateTimeWithTimeZone } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -132,7 +130,17 @@ function TimeAndLocation({ launch }) {
                     </Box>
                 </StatLabel>
                 <StatNumber fontSize={["md", "xl"]}>
-                    {formatDateTimeWithTimeZone(launch.launch_date_local, true)}
+                    <Tooltip
+                        label={formatDateTimeWithTimeZone(
+                            launch.launch_date_local,
+                            false
+                        )}
+                    >
+                        {formatDateTimeWithTimeZone(
+                            launch.launch_date_local,
+                            true
+                        )}
+                    </Tooltip>
                 </StatNumber>
                 <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
             </Stat>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -3,237 +3,245 @@ import { useParams, Link as RouterLink } from "react-router-dom";
 import { format as timeAgo } from "timeago.js";
 import { Watch, MapPin, Navigation, Layers } from "react-feather";
 import {
-  Flex,
-  Heading,
-  Badge,
-  Stat,
-  StatLabel,
-  StatNumber,
-  StatHelpText,
-  SimpleGrid,
-  Box,
-  Text,
-  Spinner,
-  Image,
-  Link,
-  Stack,
-  AspectRatioBox,
-  StatGroup,
+    Flex,
+    Heading,
+    Badge,
+    Stat,
+    StatLabel,
+    StatNumber,
+    StatHelpText,
+    SimpleGrid,
+    Box,
+    Text,
+    Spinner,
+    Image,
+    Link,
+    Stack,
+    AspectRatioBox,
+    StatGroup,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import {
+    formatDateTime,
+    formatDateTimeWithTimeZone,
+} from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
 export default function Launch() {
-  let { launchId } = useParams();
-  const { data: launch, error } = useSpaceX(`/launches/${launchId}`);
+    let { launchId } = useParams();
+    const { data: launch, error } = useSpaceX(`/launches/${launchId}`);
 
-  if (error) return <Error />;
-  if (!launch) {
+    if (error) return <Error />;
+    if (!launch) {
+        return (
+            <Flex justifyContent="center" alignItems="center" minHeight="50vh">
+                <Spinner size="lg" />
+            </Flex>
+        );
+    }
+
     return (
-      <Flex justifyContent="center" alignItems="center" minHeight="50vh">
-        <Spinner size="lg" />
-      </Flex>
+        <div>
+            <Breadcrumbs
+                items={[
+                    { label: "Home", to: "/" },
+                    { label: "Launches", to: ".." },
+                    { label: `#${launch.flight_number}` },
+                ]}
+            />
+            <Header launch={launch} />
+            <Box m={[3, 6]}>
+                <TimeAndLocation launch={launch} />
+                <RocketInfo launch={launch} />
+                <Text color="gray.700" fontSize={["md", null, "lg"]} my="8">
+                    {launch.details}
+                </Text>
+                <Video launch={launch} />
+                <Gallery images={launch.links.flickr_images} />
+            </Box>
+        </div>
     );
-  }
-
-  return (
-    <div>
-      <Breadcrumbs
-        items={[
-          { label: "Home", to: "/" },
-          { label: "Launches", to: ".." },
-          { label: `#${launch.flight_number}` },
-        ]}
-      />
-      <Header launch={launch} />
-      <Box m={[3, 6]}>
-        <TimeAndLocation launch={launch} />
-        <RocketInfo launch={launch} />
-        <Text color="gray.700" fontSize={["md", null, "lg"]} my="8">
-          {launch.details}
-        </Text>
-        <Video launch={launch} />
-        <Gallery images={launch.links.flickr_images} />
-      </Box>
-    </div>
-  );
 }
 
 function Header({ launch }) {
-  return (
-    <Flex
-      bgImage={`url(${launch.links.flickr_images[0]})`}
-      bgPos="center"
-      bgSize="cover"
-      bgRepeat="no-repeat"
-      minHeight="30vh"
-      position="relative"
-      p={[2, 6]}
-      alignItems="flex-end"
-      justifyContent="space-between"
-    >
-      <Image
-        position="absolute"
-        top="5"
-        right="5"
-        src={launch.links.mission_patch_small}
-        height={["85px", "150px"]}
-        objectFit="contain"
-        objectPosition="bottom"
-      />
-      <Heading
-        color="white"
-        display="inline"
-        backgroundColor="#718096b8"
-        fontSize={["lg", "5xl"]}
-        px="4"
-        py="2"
-        borderRadius="lg"
-      >
-        {launch.mission_name}
-      </Heading>
-      <Stack isInline spacing="3">
-        <Badge variantColor="purple" fontSize={["xs", "md"]}>
-          #{launch.flight_number}
-        </Badge>
-        {launch.launch_success ? (
-          <Badge variantColor="green" fontSize={["xs", "md"]}>
-            Successful
-          </Badge>
-        ) : (
-          <Badge variantColor="red" fontSize={["xs", "md"]}>
-            Failed
-          </Badge>
-        )}
-      </Stack>
-    </Flex>
-  );
+    return (
+        <Flex
+            bgImage={`url(${launch.links.flickr_images[0]})`}
+            bgPos="center"
+            bgSize="cover"
+            bgRepeat="no-repeat"
+            minHeight="30vh"
+            position="relative"
+            p={[2, 6]}
+            alignItems="flex-end"
+            justifyContent="space-between"
+        >
+            <Image
+                position="absolute"
+                top="5"
+                right="5"
+                src={launch.links.mission_patch_small}
+                height={["85px", "150px"]}
+                objectFit="contain"
+                objectPosition="bottom"
+            />
+            <Heading
+                color="white"
+                display="inline"
+                backgroundColor="#718096b8"
+                fontSize={["lg", "5xl"]}
+                px="4"
+                py="2"
+                borderRadius="lg"
+            >
+                {launch.mission_name}
+            </Heading>
+            <Stack isInline spacing="3">
+                <Badge variantColor="purple" fontSize={["xs", "md"]}>
+                    #{launch.flight_number}
+                </Badge>
+                {launch.launch_success ? (
+                    <Badge variantColor="green" fontSize={["xs", "md"]}>
+                        Successful
+                    </Badge>
+                ) : (
+                    <Badge variantColor="red" fontSize={["xs", "md"]}>
+                        Failed
+                    </Badge>
+                )}
+            </Stack>
+        </Flex>
+    );
 }
 
 function TimeAndLocation({ launch }) {
-  return (
-    <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
-      <Stat>
-        <StatLabel display="flex">
-          <Box as={Watch} width="1em" />{" "}
-          <Box ml="2" as="span">
-            Launch Date
-          </Box>
-        </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
-        </StatNumber>
-        <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
-      </Stat>
-      <Stat>
-        <StatLabel display="flex">
-          <Box as={MapPin} width="1em" />{" "}
-          <Box ml="2" as="span">
-            Launch Site
-          </Box>
-        </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          <Link
-            as={RouterLink}
-            to={`/launch-pads/${launch.launch_site.site_id}`}
-          >
-            {launch.launch_site.site_name_long}
-          </Link>
-        </StatNumber>
-        <StatHelpText>{launch.launch_site.site_name}</StatHelpText>
-      </Stat>
-    </SimpleGrid>
-  );
+    return (
+        <SimpleGrid
+            columns={[1, 1, 2]}
+            borderWidth="1px"
+            p="4"
+            borderRadius="md"
+        >
+            <Stat>
+                <StatLabel display="flex">
+                    <Box as={Watch} width="1em" />{" "}
+                    <Box ml="2" as="span">
+                        Launch Date
+                    </Box>
+                </StatLabel>
+                <StatNumber fontSize={["md", "xl"]}>
+                    {formatDateTimeWithTimeZone(launch.launch_date_local, true)}
+                </StatNumber>
+                <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
+            </Stat>
+            <Stat>
+                <StatLabel display="flex">
+                    <Box as={MapPin} width="1em" />{" "}
+                    <Box ml="2" as="span">
+                        Launch Site
+                    </Box>
+                </StatLabel>
+                <StatNumber fontSize={["md", "xl"]}>
+                    <Link
+                        as={RouterLink}
+                        to={`/launch-pads/${launch.launch_site.site_id}`}
+                    >
+                        {launch.launch_site.site_name_long}
+                    </Link>
+                </StatNumber>
+                <StatHelpText>{launch.launch_site.site_name}</StatHelpText>
+            </Stat>
+        </SimpleGrid>
+    );
 }
 
 function RocketInfo({ launch }) {
-  const cores = launch.rocket.first_stage.cores;
+    const cores = launch.rocket.first_stage.cores;
 
-  return (
-    <SimpleGrid
-      columns={[1, 1, 2]}
-      borderWidth="1px"
-      mt="4"
-      p="4"
-      borderRadius="md"
-    >
-      <Stat>
-        <StatLabel display="flex">
-          <Box as={Navigation} width="1em" />{" "}
-          <Box ml="2" as="span">
-            Rocket
-          </Box>
-        </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          {launch.rocket.rocket_name}
-        </StatNumber>
-        <StatHelpText>{launch.rocket.rocket_type}</StatHelpText>
-      </Stat>
-      <StatGroup>
-        <Stat>
-          <StatLabel display="flex">
-            <Box as={Layers} width="1em" />{" "}
-            <Box ml="2" as="span">
-              First Stage
-            </Box>
-          </StatLabel>
-          <StatNumber fontSize={["md", "xl"]}>
-            {cores.map((core) => core.core_serial).join(", ")}
-          </StatNumber>
-          <StatHelpText>
-            {cores.every((core) => core.land_success)
-              ? cores.length === 1
-                ? "Recovered"
-                : "All recovered"
-              : "Lost"}
-          </StatHelpText>
-        </Stat>
-        <Stat>
-          <StatLabel display="flex">
-            <Box as={Layers} width="1em" />{" "}
-            <Box ml="2" as="span">
-              Second Stage
-            </Box>
-          </StatLabel>
-          <StatNumber fontSize={["md", "xl"]}>
-            Block {launch.rocket.second_stage.block}
-          </StatNumber>
-          <StatHelpText>
-            Payload:{" "}
-            {launch.rocket.second_stage.payloads
-              .map((payload) => payload.payload_type)
-              .join(", ")}
-          </StatHelpText>
-        </Stat>
-      </StatGroup>
-    </SimpleGrid>
-  );
+    return (
+        <SimpleGrid
+            columns={[1, 1, 2]}
+            borderWidth="1px"
+            mt="4"
+            p="4"
+            borderRadius="md"
+        >
+            <Stat>
+                <StatLabel display="flex">
+                    <Box as={Navigation} width="1em" />{" "}
+                    <Box ml="2" as="span">
+                        Rocket
+                    </Box>
+                </StatLabel>
+                <StatNumber fontSize={["md", "xl"]}>
+                    {launch.rocket.rocket_name}
+                </StatNumber>
+                <StatHelpText>{launch.rocket.rocket_type}</StatHelpText>
+            </Stat>
+            <StatGroup>
+                <Stat>
+                    <StatLabel display="flex">
+                        <Box as={Layers} width="1em" />{" "}
+                        <Box ml="2" as="span">
+                            First Stage
+                        </Box>
+                    </StatLabel>
+                    <StatNumber fontSize={["md", "xl"]}>
+                        {cores.map((core) => core.core_serial).join(", ")}
+                    </StatNumber>
+                    <StatHelpText>
+                        {cores.every((core) => core.land_success)
+                            ? cores.length === 1
+                                ? "Recovered"
+                                : "All recovered"
+                            : "Lost"}
+                    </StatHelpText>
+                </Stat>
+                <Stat>
+                    <StatLabel display="flex">
+                        <Box as={Layers} width="1em" />{" "}
+                        <Box ml="2" as="span">
+                            Second Stage
+                        </Box>
+                    </StatLabel>
+                    <StatNumber fontSize={["md", "xl"]}>
+                        Block {launch.rocket.second_stage.block}
+                    </StatNumber>
+                    <StatHelpText>
+                        Payload:{" "}
+                        {launch.rocket.second_stage.payloads
+                            .map((payload) => payload.payload_type)
+                            .join(", ")}
+                    </StatHelpText>
+                </Stat>
+            </StatGroup>
+        </SimpleGrid>
+    );
 }
 
 function Video({ launch }) {
-  return (
-    <AspectRatioBox maxH="400px" ratio={1.7}>
-      <Box
-        as="iframe"
-        title={launch.mission_name}
-        src={`https://www.youtube.com/embed/${launch.links.youtube_id}`}
-        allowFullScreen
-      />
-    </AspectRatioBox>
-  );
+    return (
+        <AspectRatioBox maxH="400px" ratio={1.7}>
+            <Box
+                as="iframe"
+                title={launch.mission_name}
+                src={`https://www.youtube.com/embed/${launch.links.youtube_id}`}
+                allowFullScreen
+            />
+        </AspectRatioBox>
+    );
 }
 
 function Gallery({ images }) {
-  return (
-    <SimpleGrid my="6" minChildWidth="350px" spacing="4">
-      {images.map((image) => (
-        <a href={image} key={image}>
-          <Image src={image.replace("_o.jpg", "_z.jpg")} />
-        </a>
-      ))}
-    </SimpleGrid>
-  );
+    return (
+        <SimpleGrid my="6" minChildWidth="350px" spacing="4">
+            {images.map((image) => (
+                <a href={image} key={image}>
+                    <Image src={image.replace("_o.jpg", "_z.jpg")} />
+                </a>
+            ))}
+        </SimpleGrid>
+    );
 }

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,20 +1,29 @@
+import { DateTime } from "luxon";
+
 export function formatDate(timestamp) {
-  return new Intl.DateTimeFormat("en-US", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(new Date(timestamp));
+    return new Intl.DateTimeFormat("en-US", {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    }).format(new Date(timestamp));
 }
 
 export function formatDateTime(timestamp) {
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-    timeZoneName: "short",
-  }).format(new Date(timestamp));
+    return new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        second: "numeric",
+        timeZoneName: "short",
+    }).format(new Date(timestamp));
+}
+
+export function formatDateTimeWithTimeZone(timestamp, considerTimeZone) {
+    const keepOffset = DateTime.fromISO(timestamp, {
+        setZone: considerTimeZone,
+    }).toLocaleString(DateTime.DATETIME_FULL_WITH_SECONDS);
+    return keepOffset;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6621,6 +6621,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+luxon@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.0.2.tgz#11f2cd4a11655fdf92e076b5782d7ede5bcdd133"
+  integrity sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
## What?
I've added support for displaying lunch date and time in the local timezone of the launch site and implemented a tooltip to display it in the user's timezone when hovering over the lunch date. For more background, see ticket 
#The Pleo Frontend Challenge
## Why?
These changes enables the user to see the lunch time in both launch site timezone and local timezone and improves the user experience.
## How?
I'm using Luxon library to format the lunch date timestamp based on the timezones in order to make it simple.
## Anything Else?
Let's consider using this time library (Luxon) for timestamp formatting. Consider moment.js is deprecated and Luxon is a good alternative.

## Screenshots
### **Before changes made:**
![Before](https://user-images.githubusercontent.com/49185658/137899756-45249083-6a8c-46bf-9993-a2f862d1bc85.png)
### **After changes made:**
![After](https://user-images.githubusercontent.com/49185658/137899753-466a9bb8-2ffc-43e3-a81f-82a647eaadb1.png)

